### PR TITLE
Made changes to improve compatibility with CentOS operating systems.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,7 @@ galaxy_info:
     - precise
     - trusty
   - name: SmartOS
+  - name: CentOS
   categories:
   - networking
   - system

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,15 +27,15 @@
 ## PACKAGE INSTALL
 
 - name: 'Check epel repo'
-  stat: path=/etc/yum.repos.d/epel.repo
-  register: epel_file
+  command: yum repolist | grep -q EPEL
+  register: epel_repo_check
   when: ansible_pkg_mgr == 'yum'
 
 - name: 'Add epel repo'
   template: src=epel.repo
         dest=/etc/yum.repos.d/epel.repo
         owner=root group=root mode=0644
-  when: ansible_pkg_mgr == 'yum' and not epel_file.stat.exists
+  when: ansible_pkg_mgr == 'yum' and epel_repo_check.rc != 0
 
 - name: 'Installs haproxy as well as socat for socket api'
   yum: name={{ item }} state=latest

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
 ## PACKAGE INSTALL
 
 - name: 'Check epel repo'
-  command: yum repolist | grep -q EPEL
+  command: yum repolist | grep -qi EPEL
   register: epel_repo_check
   when: ansible_pkg_mgr == 'yum'
 
@@ -76,7 +76,7 @@
   file: path={{ etc_prefix }}/haproxy/frontends.d state=directory
 
 - name: 'Empty the folder if not already empty'
-  command: rm -f {{ etc_prefix }}/haproxy/frontends.d/*.cfg
+  command: find {{ etc_prefix }}/haproxy/frontends.d -name *.cfg -exec rm -f {} \;
 
 - name: 'Build up the frontends'
   template: src=frontend.cfg dest={{ etc_prefix }}/haproxy/frontends.d/{{ item.name }}.cfg
@@ -89,7 +89,7 @@
   file: path={{ etc_prefix }}/haproxy/backends.d state=directory
 
 - name: 'Empty the folder if not already empty'
-  command: rm -f {{ etc_prefix }}/haproxy/backends.d/*.cfg
+  command: find {{ etc_prefix }}/haproxy/backends.d -name *.cfg -exec rm -f {} \;
 
 - name: 'Build up the backends'
   template: src=backend.cfg dest={{ etc_prefix }}/haproxy/backends.d/{{ item.name }}.cfg
@@ -102,7 +102,7 @@
   file: path={{ etc_prefix }}/haproxy/listen.d state=directory
 
 - name: 'Empty the folder if not already empty'
-  command: rm -f {{ etc_prefix }}/haproxy/listen.d/*.cfg
+  command: find {{ etc_prefix }}/haproxy/listen.d -name *.cfg -exec rm -f {} \;
 
 - name: 'Build up the listen sections'
   template: src=listen.cfg dest={{ etc_prefix }}/haproxy/listen.d/{{ item.name }}.cfg
@@ -115,7 +115,7 @@
   file: path={{ etc_prefix }}/haproxy/compiled state=directory
 
 - name: 'Empty the folder if not already empty'
-  command: rm -f {{ etc_prefix }}/haproxy/compiled/*.cfg
+  command: find {{ etc_prefix }}/haproxy/compiled -name *.cfg -exec rm -f {} \;
 
 - name: 'Build up the global config'
   template: src=global.cfg dest={{ etc_prefix }}/haproxy/compiled/01-global.cfg

--- a/templates/defaults.cfg
+++ b/templates/defaults.cfg
@@ -49,10 +49,12 @@ defaults
     option {{ option }}
 {% endfor -%}
 {% endif -%}
+{% if ansible_distribution != 'CentOS' %}
 {% if haproxy_defaults.errorfile is defined %}
 {% for item in haproxy_defaults.errorfile %}
     errorfile {{ item.code }} {{ item.file }}
 {% endfor %}
+{% endif -%}
 {% endif -%}
 {% if haproxy_defaults.balance is defined %}
     balance {{ haproxy_defaults.balance }}


### PR DESCRIPTION
Putting logs in /etc/ even error logs does not really conform to any standard. If users with to set this they can do so later.

Checked for existence of EPEL repo first as automatically inserting an epel repo based apon file could break implementation into some environments where repos are silo-ed into one file.