### PR TITLE
Fixed ansible galaxy dependencies error

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,3 +15,4 @@ galaxy_info:
   - networking
   - system
   - web
+dependencies: []


### PR DESCRIPTION
```
- executing: git clone https://github.com/FloeDesignTechnologies/ansible-haproxy ansible-haproxy
- executing: git archive --prefix=ansible-haproxy/ --output=/var/folders/40/1_7mkdwj20gdf3133bdhrwgm0000gn/T/tmpTp1ddK.tar HEAD
- extracting ansible-haproxy to /usr/local/etc/ansible/roles/ansible-haproxy
---
- ansible-haproxy was installed successfully
Traceback (most recent call last):
  File "/usr/local/Cellar/ansible/1.8.3/libexec/bin/ansible-galaxy", line 954, in <module>
    main()
  File "/usr/local/Cellar/ansible/1.8.3/libexec/bin/ansible-galaxy", line 948, in main
    fn(args, options, parser)
  File "/usr/local/Cellar/ansible/1.8.3/libexec/bin/ansible-galaxy", line 842, in execute_install
    role_dependencies = role_data['dependencies']
KeyError: 'dependencies'
```

Was getting the above when trying to install via ansible galaxy