### PR TITLE
Add support for userlists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -109,6 +109,19 @@
   with_items: haproxy_listen
   when: haproxy_listen is defined
 
+## ASSEMBLE CONFIG - USERLIST
+
+- name: 'Create directory for the userlists'
+  file: path={{ etc_prefix }}/haproxy/userlists.d state=directory
+
+- name: 'Empty the folder if not already empty'
+  command: find {{ etc_prefix }}/haproxy/userlists.d -name *.cfg -exec rm -f {} \;
+
+- name: 'Build up the userlist sections'
+  template: src=userlist.cfg dest={{ etc_prefix }}/haproxy/userlists.d/{{ item.name }}.cfg
+  with_items: haproxy_userlists
+  when: haproxy_userlists is defined
+
 ## ASSEMBLE CONFIG - GLOBAL & DEFAULT
 
 - name: 'Create  the compiled folder'
@@ -136,6 +149,9 @@
 
 - name: 'Assemble the listen sections configuration file'
   assemble: src={{ etc_prefix }}/haproxy/listen.d dest={{ etc_prefix }}/haproxy/compiled/05-listen.cfg
+
+- name: 'Assemble the userlists sections configuration file'
+  assemble: src={{ etc_prefix }}/haproxy/userlists.d dest={{ etc_prefix }}/haproxy/compiled/06-userlists.cfg
 
 - name: 'Assemble the final configuration file'
   assemble: src={{ etc_prefix }}/haproxy/compiled dest={{ config_location }} backup=yes

--- a/templates/userlist.cfg
+++ b/templates/userlist.cfg
@@ -1,0 +1,14 @@
+#{{ ansible_managed }}
+userlist {{ item.name }}
+{% if item.groups is defined %}
+{% for group in item.groups %}
+    group {{ group.name }} {% if group.users is defined %} users {{ ','.join(group.users) }}{% endif %}
+
+{% endfor %}
+{% endif %}
+{% if item.users is defined %}
+{% for user in item.users %}
+    user {{ user.name }} {{ user.password }}{% if user.groups is defined %} groups {{ ','.join(user.groups) }}{% endif %}
+
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
This commit allows adding userlists if [both formats](http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#3.4) via ansible.

Example vars:
```
haproxy_userlists:
  - name: 'MyList'
    users: 
      - name: 'user1'
        password: 'insecure-password user1'
      - name: 'user2'
        password: 'insecure-password user2'
```