### PR TITLE
Add http-request option to frontends

### DIFF
--- a/templates/frontend.cfg
+++ b/templates/frontend.cfg
@@ -54,6 +54,13 @@ frontend {{ item.name }} {%if item.ip is defined %}{{ item.ip }}{% endif %}{%if 
     {% endfor -%}
     {% endif -%}
 
+    {%- if item.http_request is defined -%}
+    {%- for request in item.http_request -%}
+        http-request {{ request.action }}{% if request.param is defined %} {{ request.param }}{% endif %}{% if request.condition is defined %} {{ request.condition }}{% endif %}
+
+    {% endfor -%}
+    {% endif -%}
+
     {%- if item.tcp_request is defined -%}
     {%- for request in item.tcp_request -%}
         tcp-request {{ request.param }} {{ request.value }}{% if request.condition is defined %} {{ request.condition }}{% endif %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -61,6 +61,10 @@ empty: true
 #    acl:
 #      - name:
 #        condition:
+#    http-request:
+#      - action:
+#        param:
+#        condition:
 #    rate-limit-sessions:
 #    block:
 #        - 


### PR DESCRIPTION
This allows the use of the ['http-request'](http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#http-request) option for frontends, eg.:

```
---
haproxy_frontends:
  - name: "http-in"
    bind:
      - "{{ ansible_eth0.ipv4.address }}:80"
    default-backend: 'public-http'
    acl:
      - name: 'Users-auth-ok'
        condition: 'http_auth(users)'
    http_request:
      - action: allow
        condition: 'if Users-auth-ok'
      - action: 'auth'
        param: 'realm "My secret server"'
        condition: 'if !Users-auth-ok'
      - action: 'deny'
```