### PR TITLE
added ssl support for frontend and listen

### DIFF
--- a/templates/frontend.cfg
+++ b/templates/frontend.cfg
@@ -3,7 +3,8 @@ frontend {{ item.name }} {%if item.ip is defined %}{{ item.ip }}{% endif %}{%if 
 
     {% if item.bind is defined -%}
     {%- for bind in item.bind -%}
-        bind {{ bind }}
+        bind {{ bind }}{% if item.ssl is defined %}{% if item.ssl.cert is defined %} ssl crt {{ item.ssl.cert }}{% if item.ssl.ciphers is defined %} ciphers {{ item.ssl.ciphers }}{% endif %}{% endif %}{% endif %}
+
     {% endfor -%}
     {% endif -%}
 

--- a/templates/listen.cfg
+++ b/templates/listen.cfg
@@ -2,7 +2,8 @@
 listen {{ item.name }}
 {% if item.bind is defined %}
 {% for binding in item.bind %}
-    bind {{ binding }}
+   bind {{ binding }}{% if item.ssl is defined %}{% if item.ssl.cert is defined %} ssl crt {{ item.ssl.cert }}{% if item.ssl.ciphers is defined %} ciphers {{ item.ssl.ciphers }}{% endif %}{% endif %}{% endif %}
+
 {% endfor %}
 {% endif -%}
 {% if item.disabled is defined and item.disabled == true %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -23,7 +23,7 @@ empty: true
 #
 #haproxy_defaults:
 #  mode:
-#  log: 
+#  log:
 #  options:
 #    - <option>
 #  retries:
@@ -53,6 +53,9 @@ empty: true
 #    bind:
 #      - 192.168.1.1:80
 #      - 192.168.1.2:81
+#    ssl:
+#      cert: /etc/ssl/private/cert.pem
+#      ciphers: 'RC4-SHA:AES128-SHA:AES:!ADH:!aNULL:!DH:!EDH:!eNULL'
 #    maxconn:
 #    monitor:
 #      uri:
@@ -63,7 +66,7 @@ empty: true
 #        condition:
 #    rate-limit-sessions:
 #    block:
-#        - 
+#        -
 #    default_backend:
 #    use_backend:
 #      - name:
@@ -76,7 +79,7 @@ empty: true
 #    balance:
 #    log:
 #    retries:
-#    contimeout: 
+#    contimeout:
 #    http-send-name-header:
 #    http-check-expect:
 #        - condition
@@ -85,7 +88,7 @@ empty: true
 #        condition:
 #    servers:
 #      - name:
-#        ip: 
+#        ip:
 #        port:
 #        maxconn:
 #        params:
@@ -96,6 +99,9 @@ empty: true
 #haproxy_listen:
 #  - name:
 #    bind:
+#    ssl:
+#      cert: /etc/ssl/private/cert.pem
+#      ciphers: 'RC4-SHA:AES128-SHA:AES:!ADH:!aNULL:!DH:!EDH:!eNULL'
 #    disabled:
 #    description:
 #    balance:


### PR DESCRIPTION
Added new variables in order to setup the frontend and listen
with ssl (native support now in haproxy 1.5).
Note the pem format for the cert file.
Also included in the sample file, an example of ciphers that
can be chosen as well.