### PR TITLE
Updated check epel task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
 ## PACKAGE INSTALL
 
 - name: 'Check epel repo'
-  command: yum repolist | grep -qi EPEL
+  shell: yum repolist | grep -qi EPEL
   register: epel_repo_check
   when: ansible_pkg_mgr == 'yum'
 


### PR DESCRIPTION
Hi, I get the following error when running the module on CentOS 7 

`TASK: [info.haproxy | Check epel repo] ****************************************
failed: [192.168.0.10] => {"changed": true, "cmd": ["yum", "repolist", "|", "grep", "-qi", "EPEL"], "delta": "0:00:00.093096", "end": "2015-03-25 01:21:43.802234", "rc": 1, "start": "2015-03-25 01:21:43.709138", "warnings": ["Consider using yum module rather than running yum"]}
stderr: Command line error: no such option: -i
`

According to http://docs.ansible.com/command_module.html the `|` operator is not supported in the `command` module and the `shell` module should be used instead. 

Changing `command` to `shell` seems to fix this error on CentOS 7.