### PR TITLE
Fix http-check expect

### DIFF
--- a/templates/backend.cfg
+++ b/templates/backend.cfg
@@ -35,9 +35,9 @@ backend {{ item.name }}
 {% if item.http_send_name_header is defined %}
     http-send-name-header {{ item.http_send_name_header }}
 {% endif -%}
-{% if item.http_check_except is defined %}
-{% for check_except in item.http_check_except %}
-    http-check except {{ check_except }}
+{% if item.http_check_expect is defined %}
+{% for check_expect in item.http_check_expect %}
+    http-check expect {{ check_expect }}
 {% endfor %}
 {% endif -%}
 {% if item.options is defined %}


### PR DESCRIPTION
According to HAProxy 1.5 documentation the directive to make the health check look for specific content in the response is `http-check expect` not `http-check except`.

http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4-http-check%20expect