### PR TITLE
added timeout settings for listen, frontend and backend

### DIFF
--- a/templates/backend.cfg
+++ b/templates/backend.cfg
@@ -48,3 +48,8 @@ backend {{ item.name }}
     option {{ option }}
 {% endfor %}
 {% endif -%}
+{% if item.timeout is defined -%}
+{% for entry in item.timeout %}
+    timeout {{ entry.param }} {{ entry.value }}
+{% endfor %}
+{% endif -%}

--- a/templates/frontend.cfg
+++ b/templates/frontend.cfg
@@ -16,6 +16,12 @@ frontend {{ item.name }} {%if item.ip is defined %}{{ item.ip }}{% endif %}{%if 
         maxconn {{ item.maxconn }}
     {% endif -%}
 
+    {% if item.timeout is defined -%}
+    {% for entry in item.timeout %}
+        timeout {{ entry.param }} {{ entry.value }}
+    {% endfor %}
+    {% endif -%}
+
     {%- if item.monitor is defined -%}
        {% if item.monitor.uri is defined -%}
             monitor-uri {{ item.monitor.uri }}

--- a/templates/listen.cfg
+++ b/templates/listen.cfg
@@ -43,4 +43,8 @@ listen {{ item.name }}
     option {{ option }}
 {% endfor %}
 {% endif -%}
-
+{% if item.timeout is defined -%}
+{% for entry in item.timeout %}
+    timeout {{ entry.param }} {{ entry.value }}
+{% endfor %}
+{% endif -%}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -77,6 +77,9 @@ empty: true
 #    use_backend:
 #      - name:
 #        condition:
+#    timeout:
+#      - param:
+#        value:
 #
 #haproxy_backends:
 #  - name:
@@ -86,6 +89,8 @@ empty: true
 #    log:
 #    retries:
 #    contimeout:
+#    NOTE: contimeout is deprecated
+#          http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4-contimeout
 #    http-send-name-header:
 #    http-check-expect:
 #        - condition
@@ -101,6 +106,9 @@ empty: true
 #              - param1
 #    options:
 #        - forwardfor
+#    timeout:
+#      - param:
+#        value:
 #
 #haproxy_listen:
 #  - name:
@@ -128,3 +136,6 @@ empty: true
 #              - param1
 #    options:
 #        - forwardfor
+#    timeout:
+#      - param:
+#        value:


### PR DESCRIPTION
Up to now, only the default section could be used to set
timeouts. This adds support for timeouts in listen, frontend
and backend sections.
Note that all timeout parameters do not apply to all sections
but will not be checked for sanity by this playbook.